### PR TITLE
ci: update Swift test matrices across platforms

### DIFF
--- a/.github/workflows/ci-ios.yml
+++ b/.github/workflows/ci-ios.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        swift: ["6.2", "6.3"]
+        swift: ["6.1", "6.3"]
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci-ios.yml
+++ b/.github/workflows/ci-ios.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Swift
+        if: matrix.swift != '6.3'
         uses: swift-actions/setup-swift@v2
         with:
           swift-version: ${{ matrix.swift }}

--- a/.github/workflows/ci-ios.yml
+++ b/.github/workflows/ci-ios.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        swift: ["6.1", "6.2"]
+        swift: ["6.2", "6.3"]
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        swift: ["6.1", "6.2"]
+        swift: ["6.2", "6.3"]
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        swift: ["6.2", "6.3"]
+        swift: ["6.1", "6.2"]
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -10,11 +10,15 @@ on:
 jobs:
   macos:
     name: macOS (Swift ${{ matrix.swift }})
-    runs-on: macos-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
-        swift: ["6.2", "6.3"]
+        include:
+          - swift: "6.1"
+            runner: "macos-14"
+          - swift: "6.3"
+            runner: "macos-latest"
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        swift: ["6.1", "6.2"]
+        swift: ["6.2", "6.3"]
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Swift
+        if: matrix.swift != '6.3'
         uses: swift-actions/setup-swift@v2
         with:
           swift-version: ${{ matrix.swift }}

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        swift: ["6.2", "6.3"]
+        swift: ["6.1", "6.3"]
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        swift: ["6.1", "6.2"]
+        swift: ["6.2", "6.3"]
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Swift
         uses: swift-actions/setup-swift@v2
         with:
-          swift-version: "6.1"
+          swift-version: "6.3"
 
       - name: Build Documentation
         run: make docs-generate REPO_NAME=math DOCS_VERSION_PATH=main

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,11 +25,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup Swift
-        uses: swift-actions/setup-swift@v2
-        with:
-          swift-version: "6.3"
-
       - name: Build Documentation
         run: make docs-generate REPO_NAME=math DOCS_VERSION_PATH=main
 


### PR DESCRIPTION
### Description

Updates the CI test workflow matrices across macOS, iOS, Linux, and Windows to test Swift 6.1 and 6.3 (except Linux which tests 6.1 and 6.2), and updates the documentation build workflow to use the native system toolchain.

**Summary of changes:**
- **`.github/workflows/ci-macos.yml`**: Configured matrix for Swift 6.1 on `macos-14` runner and Swift 6.3 on `macos-latest` runner, skipping `setup-swift` for 6.3.
- **`.github/workflows/ci-ios.yml`**: Updated matrix to Swift 6.1 and 6.3, skipping `setup-swift` for 6.3.
- **`.github/workflows/ci-linux.yml`**: Updated matrix to Swift 6.1 and 6.2.
- **`.github/workflows/ci-windows.yml`**: Updated matrix to Swift 6.1 and 6.3.
- **`.github/workflows/docs.yml`**: Removed redundant `setup-swift` step to build documentation using native system Xcode on `macos-latest`.

### Rationale

Resolves toolchain and SDK mismatch failures on `macos-latest` runners by utilizing native system Xcode toolchains for Swift 6.3 and matching runner environments (`macos-14`) for Swift 6.1. Ensures all platforms maintain target Swift compatibility testing.

### Detailed Design

Adjusted workflow matrix configurations, runner assignments, and toolchain setup conditions in GitHub Actions workflow files.

### Testing

Verified all 10 CI jobs across macOS, iOS, Linux, Windows, and Documentation pass on GitHub Actions for PR 50.

### Source Impact

No impact on package source code; configuration changes strictly apply to CI workflow execution.

### Checklist

- [x] I've read the [Contribution Guidelines](https://github.com/fireblade-engine/math/blob/master/CONTRIBUTING.md)
- [x] I've followed the coding style of the rest of the project.
- [x] I've verified that my change does not break any existing tests or introduce unexpected benchmark regressions.
- [x] I've updated the documentation (if appropriate).
