### PR TITLE
chore(renovate): suppress notifications and clear assignees/reviewers

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,5 +21,12 @@
   ],
   "labels": [
     "dependencies"
+  ],
+  "reviewers": [],
+  "assignees": [],
+  "suppressNotifications": [
+    "prIgnoreNotification",
+    "prEditNotification",
+    "branchAutomergeFailure"
   ]
 }


### PR DESCRIPTION
### Description

Updates `renovate.json` to configure empty `reviewers` and `assignees` arrays and add `suppressNotifications` options (`prIgnoreNotification`, `prEditNotification`, `branchAutomergeFailure`), matching the Renovate configuration in `dailygrind-2024`.

**Summary of changes:**
- **`renovate.json`**: Added `"reviewers": []`, `"assignees": []`, and `"suppressNotifications": ["prIgnoreNotification", "prEditNotification", "branchAutomergeFailure"]`

### Rationale

Prevents Renovate from automatically assigning PRs, requesting reviews, or sending unwanted PR edit/ignore notification emails.

### Detailed Design

Adjusted Renovate bot JSON configuration rules.

### Testing

Verified JSON syntax validity.

### Source Impact

No impact on package source code; configuration changes strictly apply to Renovate bot behavior.

### Checklist

- [x] I've read the [Contribution Guidelines](https://github.com/fireblade-engine/math/blob/master/CONTRIBUTING.md)
- [x] I've followed the coding style of the rest of the project.
- [x] I've verified that my change does not break any existing tests or introduce unexpected benchmark regressions.
- [x] I've updated the documentation (if appropriate).
