### PR TITLE
chore(renovate): improve dependency grouping and validate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -47,7 +47,7 @@
   "reviewers": [],
   "suppressNotifications": [
     "prIgnoreNotification",
-    "prEditNotification",
+    "prEditedNotification",
     "branchAutomergeFailure"
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -3,20 +3,41 @@
   "extends": [
     "config:recommended"
   ],
-  "prConcurrentLimit": 3,
-  "prHourlyLimit": 1,
   "recreateWhen": "auto",
   "prCreation": "not-pending",
   "packageRules": [
     {
-      "description": "Accumulate non-major updates into one pull request",
+      "groupName": "Swift non-major dependencies",
+      "description": "Group all Swift package minor and patch updates together",
+      "matchManagers": [
+        "swift"
+      ],
       "matchUpdateTypes": [
         "minor",
         "patch"
+      ]
+    },
+    {
+      "groupName": "Mint non-major dependencies",
+      "description": "Group all Mint package minor and patch updates together",
+      "matchManagers": [
+        "mint"
       ],
-      "matchCurrentVersion": ">=1",
-      "groupName": "all non-major dependencies",
-      "groupSlug": "all-minor-patch"
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ]
+    },
+    {
+      "groupName": "GitHub Actions non-major dependencies",
+      "description": "Group all GitHub Actions minor and patch updates together",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ]
     }
   ],
   "labels": [

--- a/renovate.json
+++ b/renovate.json
@@ -1,14 +1,16 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "assignees": [],
   "extends": [
     "config:recommended"
   ],
-  "recreateWhen": "auto",
-  "prCreation": "not-pending",
+  "labels": [
+    "dependencies"
+  ],
   "packageRules": [
     {
-      "groupName": "Swift non-major dependencies",
       "description": "Group all Swift package minor and patch updates together",
+      "groupName": "Swift non-major dependencies",
       "matchManagers": [
         "swift"
       ],
@@ -18,8 +20,8 @@
       ]
     },
     {
-      "groupName": "Mint non-major dependencies",
       "description": "Group all Mint package minor and patch updates together",
+      "groupName": "Mint non-major dependencies",
       "matchManagers": [
         "mint"
       ],
@@ -29,8 +31,8 @@
       ]
     },
     {
-      "groupName": "GitHub Actions non-major dependencies",
       "description": "Group all GitHub Actions minor and patch updates together",
+      "groupName": "GitHub Actions non-major dependencies",
       "matchManagers": [
         "github-actions"
       ],
@@ -40,11 +42,9 @@
       ]
     }
   ],
-  "labels": [
-    "dependencies"
-  ],
+  "prCreation": "not-pending",
+  "recreateWhen": "auto",
   "reviewers": [],
-  "assignees": [],
   "suppressNotifications": [
     "prIgnoreNotification",
     "prEditNotification",


### PR DESCRIPTION
## Summary
- Group non-major updates by manager (`swift`, `mint`, `github-actions`) to prevent failures in one manager from blocking updates in others.
- Remove `matchCurrentVersion: ">=1"` constraint to include `0.x` dependencies in non-major groupings.
- Remove `prConcurrentLimit` and `prHourlyLimit`.
- Fix typo in `prEditedNotification` in `suppressNotifications`.
- Sort `renovate.json` keys alphabetically via `jq -S`.
- Validated configuration with official `renovate-config-validator`.