### PR TITLE
Move Renovate configuration to .github and configure automerge and codeowners

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -31,20 +31,19 @@
       ]
     },
     {
-      "description": "Group all GitHub Actions minor and patch updates together",
-      "groupName": "GitHub Actions non-major dependencies",
+      "description": "Group and automerge all GitHub Actions updates together",
+      "groupName": "GitHub Actions dependencies",
       "matchManagers": [
         "github-actions"
       ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ]
+      "automerge": true,
+      "automergeType": "branch"
     }
   ],
   "prCreation": "not-pending",
   "recreateWhen": "auto",
   "reviewers": [],
+  "reviewersFromCodeOwners": false,
   "suppressNotifications": [
     "prIgnoreNotification",
     "prEditedNotification",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -31,13 +31,17 @@
       ]
     },
     {
-      "description": "Group and automerge all GitHub Actions updates together",
-      "groupName": "GitHub Actions dependencies",
+      "description": "Group and automerge non-major GitHub Actions updates",
+      "groupName": "GitHub Actions non-major dependencies",
       "matchManagers": [
         "github-actions"
       ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
       "automerge": true,
-      "automergeType": "branch"
+      "automergeType": "pr"
     }
   ],
   "prCreation": "not-pending",


### PR DESCRIPTION
## Context & Summary

### What
- Relocated the Renovate configuration file from the repository root `renovate.json` to `.github/renovate.json`.
- Added `"reviewersFromCodeOwners": false` to the Renovate configuration.
- Configured `"automerge": true` and `"automergeType": "pr"` for non-major (`minor`, `patch`) GitHub Actions dependency updates.

### Why
- **Review Assignments & Email Notifications**: Automatically requested reviews from `/CODEOWNERS` triggered unwanted email notifications on Renovate PRs. Adding `"reviewersFromCodeOwners": false` prevents Renovate from assigning reviewers based on `/CODEOWNERS`.
- **Automerge**: Automatically merges minor and patch GitHub Actions updates once CI checks pass, reducing manual overhead while complying with GitHub branch protection PR requirements.
- **Repository Organization**: Places the configuration file in the standard `.github/` folder alongside GitHub Actions workflow definitions.

### Where
- `.github/renovate.json` (moved from `renovate.json`)

---

## Reviewer Guidance

### How to Test / Verify
1. Run local validation:
   ```bash
   npx --yes --package renovate -- renovate-config-validator .github/renovate.json
   ```
2. Confirm the validator reports successful validation with zero warnings or errors.

### Risk of Regression
- **Low**: Changes only affect Renovate execution options. Non-major GitHub Actions updates will automerge after CI passes; major version updates continue to require manual review.

### Focus Areas
- `.github/renovate.json`: Confirm `reviewersFromCodeOwners`, `automerge`, and `automergeType` settings align with repository policies.