### PR TITLE
Remove prCreation setting to restore immediate PR creation

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -44,7 +44,6 @@
       "automergeType": "pr"
     }
   ],
-  "prCreation": "not-pending",
   "recreateWhen": "auto",
   "reviewers": [],
   "reviewersFromCodeOwners": false,


### PR DESCRIPTION
## Context & Summary

### What
- Removed `"prCreation": "not-pending"` from `.github/renovate.json`.

### Why
- **Immediate PR Creation**: Removing `"prCreation": "not-pending"` restores Renovate's default behavior (`"immediate"`), ensuring Pull Requests are opened immediately upon branch creation rather than waiting for CI status checks to complete.

### Where
- `.github/renovate.json`

---

## Reviewer Guidance

### How to Test / Verify
1. Run local validation:
   ```bash
   npx --yes --package renovate -- renovate-config-validator .github/renovate.json
   ```
2. Confirm the validator passes with zero warnings or errors.

### Risk of Regression
- **Low**: Reverts `prCreation` back to Renovate's default setting.

### Focus Areas
- `.github/renovate.json`: Verify removal of `"prCreation": "not-pending"`.